### PR TITLE
Fix non-relative paths

### DIFF
--- a/extract_zim.rs
+++ b/extract_zim.rs
@@ -69,7 +69,12 @@ fn main() {
                     let mut s = String::new();
                     s.push(entry.namespace);
                     let out_path = root_output.join(&s).join(&entry.url);
-                    safe_write(&out_path, cluster.get_blob(bid), 1);
+                    if out_path.starts_with(&out) {
+                      safe_write(&out_path, cluster.get_blob(bid), 1);
+                    } else {
+                      let new_out=&root_output.join(Path::new(&out_path.to_str().unwrap().replacen("/","./",1)));
+                      safe_write(&new_out, cluster.get_blob(bid), 1);
+                    }
                 }
             }
         });


### PR DESCRIPTION
Some paths were non-relative and I got errors like
```
thread '<unnamed>' panicked at 'failed to create /fulltextIndex: permission denied', extract_zim.rs:153
```

This pr fixes them.
Disclaimer: I never have written something in rust before