### PR TITLE
fix redirect race

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ xz2 = "^0.1"
 crossbeam = "^0.3"
 bitreader = "^0.3"
 scoped_threadpool = "^0.1"
+num_cpus = "0.2"
 
 [[bin]]
 name = "extract_zim"


### PR DESCRIPTION
* when processing redirects, the source does not necessarily yet exist -
this patch will queue and process them at the end
* limit parallelism to cpu count
* rustfmt

a bit of a quick-and-dirty way to solve the problem, but fixes the issue