### PR TITLE
fix(extract): write jpeg files with a '.jpg' extension

### DIFF
--- a/src/bin/extract_zim.rs
+++ b/src/bin/extract_zim.rs
@@ -276,7 +276,7 @@ fn make_path(root: &Path, namespace: Namespace, url: &str, mime_type: &MimeType)
     if let MimeType::Type(typ) = mime_type {
         let extension = match typ.as_str() {
             "text/html" => Some("html"),
-            "image/jpeg" => Some("jpeg"),
+            "image/jpeg" => Some("jpg"),
             "image/png" => Some("png"),
             "image/gif" => Some("gif"),
             "image/svg+xml" => Some("svg"),


### PR DESCRIPTION
The links inside the wikipedia zim files assume the linked
images will have a '.jpg' extension, previously the zim extract was saving jpeg files as 'example.jpeg', they will now be saved as `example.jpg`.

This is part of the issue mentioned in #6